### PR TITLE
fix: copy assets back to the image after oscap remediation

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -9,7 +9,12 @@ RUN chmod +x /tmp/scripts/*.sh /tmp/scripts/build/*.sh && \
     /tmp/scripts/setup.sh && \
     /tmp/scripts/build.sh && \
     /tmp/scripts/cleanup.sh && \
-    rm -rf /tmp && \
+    rm -rf /tmp/* && \
     bootc container lint
+
+# Some files have been altered by the oscap remediation, so we need to
+# overwrite them.  Once we are able to skip specific rules, we can remove this
+# step.
+COPY files/ /
 
 CMD /sbin/init


### PR DESCRIPTION
Some files have been altered by the oscap remediation, so we need to
overwrite them.  Once we are able to skip specific rules, we can remove this
step.